### PR TITLE
chore: Add request tracking and additional web3 diagnostics

### DIFF
--- a/onchain/data_permissions.py
+++ b/onchain/data_permissions.py
@@ -51,8 +51,16 @@ class DataPermissions:
 
             # Call the permissions function
             logger.info(f"[DATA_PERMISSIONS] About to call contract.functions.permissions({permission_id})")
+            logger.info(f"[DATA_PERMISSIONS] Permission ID type: {type(permission_id)}, value: {permission_id}")
             logger.info(f"[DATA_PERMISSIONS] Contract object: {self.contract}")
-            logger.info(f"[DATA_PERMISSIONS] Contract functions: {dir(self.contract.functions)}")
+            logger.info(f"[DATA_PERMISSIONS] Contract address hex: {self.contract.address}")
+            
+            # Log the exact call data that will be sent
+            try:
+                call_data = self.contract.encodeABI(fn_name='permissions', args=[permission_id])
+                logger.info(f"[DATA_PERMISSIONS] Encoded call data: {call_data}")
+            except Exception as e:
+                logger.error(f"[DATA_PERMISSIONS] Failed to encode ABI: {e}")
             
             # THIS IS THE CRITICAL LINE WHERE IT CRASHES
             logger.info(f"[DATA_PERMISSIONS] *** CALLING CONTRACT NOW ***")
@@ -66,6 +74,16 @@ class DataPermissions:
                 call_obj = permissions_func(permission_id)
                 logger.info(f"[DATA_PERMISSIONS] Call object created: {call_obj}")
                 logger.info(f"[DATA_PERMISSIONS] About to execute .call()")
+                
+                # Try a raw RPC call first to see if it's the contract call or RPC in general
+                try:
+                    logger.info(f"[DATA_PERMISSIONS] Testing raw RPC call - getting block number")
+                    block_num = self.web3.eth.block_number
+                    logger.info(f"[DATA_PERMISSIONS] Raw RPC succeeded, block: {block_num}")
+                except Exception as e:
+                    logger.error(f"[DATA_PERMISSIONS] Raw RPC failed: {e}")
+                
+                logger.info(f"[DATA_PERMISSIONS] Now attempting contract call")
                 permission_data = call_obj.call()
                 logger.info(f"[DATA_PERMISSIONS] *** CONTRACT CALL SUCCEEDED ***")
             except Exception as e:

--- a/services/operations.py
+++ b/services/operations.py
@@ -64,8 +64,13 @@ class OperationsService:
         logger.info("[OPERATIONS INIT] OperationsService initialization complete")
 
     def create(self, request_json: str, signature: str) -> ExecuteResponse:
+        import uuid
+        request_id = str(uuid.uuid4())[:8]
+        logger.info(f"[REQUEST {request_id}] Starting create operation")
+        
         try:
             request = PersonalServerRequest(**json.loads(request_json))
+            logger.info(f"[REQUEST {request_id}] Parsed request with permission_id: {request.permission_id}")
         except (json.JSONDecodeError, TypeError) as e:
             raise ValidationError(
                 "Invalid JSON format in operation request", "operation_request_json"
@@ -76,14 +81,16 @@ class OperationsService:
 
         try:
             app_address = self._recover_app_address(request_json, signature)
-            logger.info(f"Recovered app address: {app_address}")
+            logger.info(f"[REQUEST {request_id}] Recovered app address: {app_address}")
         except Exception as e:
             raise AuthenticationError(
                 "Invalid signature or unable to recover app address"
             )
 
+        logger.info(f"[REQUEST {request_id}] Moving to permission fetch phase")
+        
         try:
-            logger.info(f"[OPERATIONS] About to fetch permission {request.permission_id} from blockchain")
+            logger.info(f"[REQUEST {request_id}] About to fetch permission {request.permission_id} from blockchain")
             logger.info(f"[OPERATIONS] DataPermissions object: {self.data_permissions}")
             logger.info(f"[OPERATIONS] DataPermissions class: {type(self.data_permissions).__name__}")
             


### PR DESCRIPTION
Clean PR with focused diagnostic additions to help identify the web3 crash pattern.

## Changes
- Add request ID (uuid) to track individual requests through logs
- Add raw RPC test (get block number) before contract call to see if all RPC calls fail
- Add permission ID type/value logging and encoded ABI data
- Add 'Moving to permission fetch phase' log to confirm crash location

## Why this helps
1. Request IDs will show if Cloud Run is retrying failed requests
2. Raw RPC test will tell us if it's all web3 calls or just contract calls
3. Permission ID logging may reveal a pattern in which IDs cause crashes
4. Encoded ABI will show the exact data being sent

## Test plan
- Deploy and monitor logs for crash patterns
- Look for correlation between permission IDs and crashes
- Check if raw RPC calls also trigger the crash

🤖 Generated with [Claude Code](https://claude.ai/code)