### PR TITLE
feat: add jq to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     procps \
+    jq \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Adds jq package to the Docker image for JSON processing capabilities in the Cloud Run container.

Changes:
- Added jq to apt-get install in Dockerfile